### PR TITLE
Update peewee_versioned.py

### DIFF
--- a/peewee_versioned/peewee_versioned.py
+++ b/peewee_versioned/peewee_versioned.py
@@ -270,5 +270,5 @@ class VersionedModel(with_metaclass(MetaModel, Model)):
     def _finalize_current_version(self):
         current_version = self._get_current_version()
         if current_version is not None:
-            current_version._valid_until = datetime.datetime.utcnow()
+            current_version._valid_until = datetime.datetime.now()
             current_version.save()


### PR DESCRIPTION
"_valid_from" is recorded as local timestamp, "_valid_until" is recorded as UTC timestamp.
